### PR TITLE
refactor: Remove unused import from utils.ts

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,4 @@
 import { cubicOut } from "svelte/easing";
-import { get } from "svelte/store";
 import { showToastMessage } from "@itsfuad/domtoastmessage";
 import { buttonSoundEnabled, messageSoundEnabled } from "$lib/settings.svelte";
 import { browser } from "$app/environment";


### PR DESCRIPTION
This pull request includes a minor change to the `src/lib/utils.ts` file. The change involves removing an unused import statement to clean up the code.

* [`src/lib/utils.ts`](diffhunk://#diff-da10bcc7d8dff796f50c9358a7268eb5abd2c50f460aecc4b2be1c691a966224L2): Removed the unused import statement for the `get` function from `svelte/store`.